### PR TITLE
Added support for setting tag on npm publish

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -13,6 +13,8 @@ The following parameters are used to configure the plugin:
   (uses the workspace directory, by default)
 * **tag** - the tag to use when publishing the package (does not set
   one by default)
+* **access* - the access level to use for scoped packages (does not set
+  one by default)
 
 The following secret values can be set to configure the plugin.
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -11,6 +11,8 @@ The following parameters are used to configure the plugin:
 * **registry** - the registry URL to use (https://registry.npmjs.org by default)
 * **folder** - the folder, relative to the workspace, containing the library
   (uses the workspace directory, by default)
+* **tag** - the tag to use when publishing the package (does not set
+  one by default)
 
 The following secret values can be set to configure the plugin.
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,11 @@ func main() {
 			Usage:  "NPM publish tag",
 			EnvVar: "PLUGIN_TAG",
 		},
+		cli.StringFlag{
+			Name:   "access",
+			Usage:  "NPM scoped package access",
+			EnvVar: "PLUGIN_ACCESS",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -85,6 +90,7 @@ func run(c *cli.Context) error {
 			Folder:     c.String("folder"),
 			SkipVerify: c.Bool("skip_verify"),
 			Tag:        c.String("tag"),
+			Access:     c.String("access"),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -58,6 +58,11 @@ func main() {
 			Name:  "env-file",
 			Usage: "source env file",
 		},
+		cli.StringFlag{
+			Name:   "tag",
+			Usage:  "NPM publish tag",
+			EnvVar: "PLUGIN_TAG",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -79,6 +84,7 @@ func run(c *cli.Context) error {
 			Registry:   c.String("registry"),
 			Folder:     c.String("folder"),
 			SkipVerify: c.Bool("skip_verify"),
+			Tag:        c.String("tag"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -27,6 +27,7 @@ type (
 		Folder     string
 		SkipVerify bool
 		Tag        string
+		Access     string
 	}
 
 	npmPackage struct {
@@ -309,11 +310,17 @@ func packageVersionsCommand(name string) *exec.Cmd {
 
 // publishCommand runs the publish command
 func publishCommand(config Config) *exec.Cmd {
-	if len(config.Tag) == 0 {
-		return exec.Command("npm", "publish");
-	} else {
-		return exec.Command("npm", "publish", "--tag", config.Tag);
+	commandArgs := []string{"publish"};
+
+	if len(config.Tag) != 0 {
+		commandArgs = append(commandArgs, "--tag", config.Tag);
 	}
+
+	if len(config.Access) != 0 {
+		commandArgs = append(commandArgs, "--access", config.Access);
+	}
+
+	return exec.Command("npm", commandArgs...);
 }
 
 // trace writes each command to standard error (preceded by a ‘$ ’) before it

--- a/plugin.go
+++ b/plugin.go
@@ -26,6 +26,7 @@ type (
 		Registry   string
 		Folder     string
 		SkipVerify bool
+		Tag        string
 	}
 
 	npmPackage struct {
@@ -81,7 +82,7 @@ func (p Plugin) Exec() error {
 		log.Info("Publishing package")
 
 		// run the publish command
-		return runCommand(publishCommand(), p.Config.Folder)
+		return runCommand(publishCommand(p.Config), p.Config.Folder)
 	}
 
 	return nil
@@ -307,8 +308,12 @@ func packageVersionsCommand(name string) *exec.Cmd {
 }
 
 // publishCommand runs the publish command
-func publishCommand() *exec.Cmd {
-	return exec.Command("npm", "publish")
+func publishCommand(config Config) *exec.Cmd {
+	if len(config.Tag) == 0 {
+		return exec.Command("npm", "publish");
+	} else {
+		return exec.Command("npm", "publish", "--tag", config.Tag);
+	}
 }
 
 // trace writes each command to standard error (preceded by a ‘$ ’) before it


### PR DESCRIPTION
We've run into situations where we wish to push pre-release versions of npm packages from drone updating a separate dist-tag (like beta, test or pre-release) rather than latest.