### PR TITLE
feat(cli): added corresponding npm env variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,12 +47,12 @@ func main() {
 		cli.StringFlag{
 			Name:   "folder",
 			Usage:  "folder containing package.json",
-			EnvVar: "PLUGIN_FOLDER",
+			EnvVar: "PLUGIN_FOLDER,NPM_FOLDER",
 		},
 		cli.BoolFlag{
 			Name:   "skip_verify",
 			Usage:  "skip SSL verification",
-			EnvVar: "PLUGIN_SKIP_VERIFY",
+			EnvVar: "PLUGIN_SKIP_VERIFY,NPM_SKIP_VERIFY",
 		},
 		cli.StringFlag{
 			Name:  "env-file",
@@ -61,12 +61,12 @@ func main() {
 		cli.StringFlag{
 			Name:   "tag",
 			Usage:  "NPM publish tag",
-			EnvVar: "PLUGIN_TAG",
+			EnvVar: "PLUGIN_TAG,NPM_TAG",
 		},
 		cli.StringFlag{
 			Name:   "access",
 			Usage:  "NPM scoped package access",
-			EnvVar: "PLUGIN_ACCESS",
+			EnvVar: "PLUGIN_ACCESS,NPM_ACCESS",
 		},
 	}
 


### PR DESCRIPTION
A few instances of Drone I have seen use environmental variables such as `NPM_EMAIL` and `NPM_REGISTRY`. This PR adds an `NPM_*` version of the `PLUGIN_*` variables that did not already have a corresponding npm variable.

Please let me know if you need anything else from this PR. This is the first time I've run across Go so if I missed a test that needs to be updated let me know.