### PR TITLE
Add flag to fail publishing if version conflict in NPM

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,9 +55,9 @@ func main() {
 			EnvVar: "PLUGIN_SKIP_VERIFY",
 		},
 		cli.BoolFlag{
-			Name:   "fail_if_conflict",
-			Usage:  "fail NPM publish if version already exists",
-			EnvVar: "PLUGIN_FAIL_IF_CONFLICT",
+			Name:   "fail_on_version_conflict",
+			Usage:  "fail NPM publish if version already exists in NPM registry",
+			EnvVar: "PLUGIN_FAIL_ON_VERSION_CONFLICT",
 		},
 		cli.StringFlag{
 			Name:  "env-file",
@@ -87,16 +87,16 @@ func run(c *cli.Context) error {
 
 	plugin := Plugin{
 		Config: Config{
-			Username:       c.String("username"),
-			Password:       c.String("password"),
-			Token:          c.String("token"),
-			Email:          c.String("email"),
-			Registry:       c.String("registry"),
-			Folder:         c.String("folder"),
-			SkipVerify:     c.Bool("skip_verify"),
-			FailIfConflict: c.Bool("fail_if_conflict"),
-			Tag:            c.String("tag"),
-			Access:         c.String("access"),
+			Username:              c.String("username"),
+			Password:              c.String("password"),
+			Token:                 c.String("token"),
+			Email:                 c.String("email"),
+			Registry:              c.String("registry"),
+			Folder:                c.String("folder"),
+			SkipVerify:            c.Bool("skip_verify"),
+			FailOnVersionConflict: c.Bool("fail_on_version_conflict"),
+			Tag:                   c.String("tag"),
+			Access:                c.String("access"),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,11 @@ func main() {
 			Usage:  "skip SSL verification",
 			EnvVar: "PLUGIN_SKIP_VERIFY",
 		},
+		cli.BoolFlag{
+			Name:   "fail_if_conflict",
+			Usage:  "fail NPM publish if version already exists",
+			EnvVar: "PLUGIN_FAIL_IF_CONFLICT",
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -82,15 +87,16 @@ func run(c *cli.Context) error {
 
 	plugin := Plugin{
 		Config: Config{
-			Username:   c.String("username"),
-			Password:   c.String("password"),
-			Token:      c.String("token"),
-			Email:      c.String("email"),
-			Registry:   c.String("registry"),
-			Folder:     c.String("folder"),
-			SkipVerify: c.Bool("skip_verify"),
-			Tag:        c.String("tag"),
-			Access:     c.String("access"),
+			Username:       c.String("username"),
+			Password:       c.String("password"),
+			Token:          c.String("token"),
+			Email:          c.String("email"),
+			Registry:       c.String("registry"),
+			Folder:         c.String("folder"),
+			SkipVerify:     c.Bool("skip_verify"),
+			FailIfConflict: c.Bool("fail_if_conflict"),
+			Tag:            c.String("tag"),
+			Access:         c.String("access"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -19,16 +19,16 @@ import (
 type (
 	// Config for the plugin.
 	Config struct {
-		Username       string
-		Password       string
-		Token          string
-		Email          string
-		Registry       string
-		Folder         string
-		SkipVerify     bool
-		FailIfConflict bool
-		Tag            string
-		Access         string
+		Username              string
+		Password              string
+		Token                 string
+		Email                 string
+		Registry              string
+		Folder                string
+		SkipVerify            bool
+		FailOnVersionConflict bool
+		Tag                   string
+		Access                string
 	}
 
 	npmPackage struct {
@@ -253,7 +253,7 @@ func shouldPublishPackage(config Config, npm *npmPackage) (bool, error) {
 
 			if strings.Compare(npm.Version, value) == 0 {
 				log.Info("Version found in the registry")
-				if config.FailIfConflict {
+				if config.FailOnVersionConflict {
 					return false, errors.New("Cannot publish package due to version conflict")
 				}
 				return false, nil

--- a/plugin.go
+++ b/plugin.go
@@ -19,15 +19,16 @@ import (
 type (
 	// Config for the plugin.
 	Config struct {
-		Username   string
-		Password   string
-		Token      string
-		Email      string
-		Registry   string
-		Folder     string
-		SkipVerify bool
-		Tag        string
-		Access     string
+		Username       string
+		Password       string
+		Token          string
+		Email          string
+		Registry       string
+		Folder         string
+		SkipVerify     bool
+		FailIfConflict bool
+		Tag            string
+		Access         string
 	}
 
 	npmPackage struct {
@@ -252,6 +253,9 @@ func shouldPublishPackage(config Config, npm *npmPackage) (bool, error) {
 
 			if strings.Compare(npm.Version, value) == 0 {
 				log.Info("Version found in the registry")
+				if config.FailIfConflict {
+					return false, errors.New("Cannot publish package due to version conflict")
+				}
 				return false, nil
 			}
 		}


### PR DESCRIPTION
Builds can silently fail if plugin tries to publish a package version that already exists in the target registry. To avoid this, this pull request adds an additional flag that forces the plugin to fail if there is a version conflict. Defaults to existing behavior if not specified.

Usage:
```
docker run --rm \
  -e NPM_USERNAME=drone \
  -e NPM_PASSWORD=password \
  -e NPM_EMAIL=drone@drone.io \
  -e PLUGIN_FAIL_ON_VERSION_CONFLICT=true \
  -v $(pwd):$(pwd) \
  -w $(pwd) \
  plugins/npm
``` 