### PR TITLE
Allow for Hosts to have paths with tokens

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -282,7 +282,8 @@ func npmrcContentsUsernamePassword(config Config) string {
 /// Writes npmrc contents when using a token
 func npmrcContentsToken(config Config) string {
 	registry, _ := url.Parse(config.Registry)
-	return fmt.Sprintf("//%s/:_authToken=%s", registry.Host, config.Token)
+	registry.Scheme = "" // Reset the scheme to empty. This makes it so we will get a protocol relative URL.
+	return fmt.Sprintf("%s:_authToken=%s", registry.String(), config.Token)
 }
 
 // versionCommand gets the npm version

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestTokenRCContents(t *testing.T) {
+	conf := Config{
+		Registry: "https://npm.someorg.com/",
+		Token:    "token",
+	}
+	actual := npmrcContentsToken(conf)
+	expected := "//npm.someorg.com/:_authToken=token"
+	if actual != expected {
+		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
+	}
+
+	conf.Registry = "https://npm.someorg.com/with/path/"
+	actual = npmrcContentsToken(conf)
+	expected = "//npm.someorg.com/with/path/:_authToken=token"
+	if actual != expected {
+		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
+	}
+}


### PR DESCRIPTION
This changes the config from only passing the host through to allowing for the inclusion of a path with it.

