### PR TITLE
Fix for default case of using GlobalRegistry with a token

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -285,7 +285,7 @@ func npmrcContentsToken(config Config) string {
 	registry.Scheme = "" // Reset the scheme to empty. This makes it so we will get a protocol relative URL.
 	registryString := registry.String()
 
-	if registryString[len(registryString)-1] != '/' {
+	if !strings.HasSuffix(registryString, "/") {
 		registryString = registryString + "/"
 	}
 	return fmt.Sprintf("%s:_authToken=%s", registryString, config.Token)

--- a/plugin.go
+++ b/plugin.go
@@ -283,7 +283,12 @@ func npmrcContentsUsernamePassword(config Config) string {
 func npmrcContentsToken(config Config) string {
 	registry, _ := url.Parse(config.Registry)
 	registry.Scheme = "" // Reset the scheme to empty. This makes it so we will get a protocol relative URL.
-	return fmt.Sprintf("%s:_authToken=%s", registry.String(), config.Token)
+	registryString := registry.String()
+
+	if registryString[len(registryString)-1] != '/' {
+		registryString = registryString + "/"
+	}
+	return fmt.Sprintf("%s:_authToken=%s", registryString, config.Token)
 }
 
 // versionCommand gets the npm version

--- a/plugin.go
+++ b/plugin.go
@@ -48,7 +48,7 @@ type (
 )
 
 // GlobalRegistry defines the default NPM registry.
-const GlobalRegistry = "https://registry.npmjs.org"
+const GlobalRegistry = "https://registry.npmjs.org/"
 
 // Exec executes the plugin.
 func (p Plugin) Exec() error {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -21,4 +21,11 @@ func TestTokenRCContents(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
 	}
+
+	conf.Registry = GlobalRegistry
+	actual = npmrcContentsToken(conf)
+	expected = "//registry.npmjs.org/:_authToken=token"
+	if actual != expected {
+		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
+	}
 }

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -28,4 +28,18 @@ func TestTokenRCContents(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
 	}
+
+	conf.Registry = "https://npm.someorg.com"
+	actual = npmrcContentsToken(conf)
+	expected = "//npm.someorg.com/:_authToken=token"
+	if actual != expected {
+		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
+	}
+
+	conf.Registry = "https://npm.someorg.com/with/path"
+	actual = npmrcContentsToken(conf)
+	expected = "//npm.someorg.com/with/path/:_authToken=token"
+	if actual != expected {
+		t.Errorf("Unexpected token config (Got: %s, Expected: %s)", actual, expected)
+	}
 }


### PR DESCRIPTION
Pull Request #50 appears to have caused a regression that prevents usage of GlobalRegistry with a token.

Please see issue #51 for details of the error.  A test has also been included to show how it was failing.

## Proposed solution
GlobalRegistry now needs to follow the conventions from #50 to include an '/' at the end.