### PR TITLE
change whoami command from required to optional

### DIFF
--- a/cmd/drone-npm/config.go
+++ b/cmd/drone-npm/config.go
@@ -37,6 +37,12 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			EnvVars:     []string{"PLUGIN_TOKEN", "NPM_TOKEN"},
 			Destination: &settings.Token,
 		},
+		&cli.BoolFlag{
+			Name:        "skip-whoami",
+			Usage:       "Skip credentials verification by running npm whoami command",
+			EnvVars:     []string{"PLUGIN_SKIP_WHOAMI", "NPM_SKIP_WHOAMI"},
+			Destination: &settings.SkipWhoami,
+		},
 		&cli.StringFlag{
 			Name:        "registry",
 			Usage:       "NPM registry",

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -5,7 +5,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache git nodejs nodejs-npm
+RUN apk add --no-cache git nodejs npm
 
 ADD release/linux/amd64/drone-npm /bin/
 ENTRYPOINT [ "/bin/drone-npm" ]

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -5,7 +5,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache git nodejs nodejs-npm
+RUN apk add --no-cache git nodejs npm
 
 ADD release/linux/arm/drone-npm /bin/
 ENTRYPOINT [ "/bin/drone-npm" ]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -5,7 +5,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache git nodejs nodejs-npm
+RUN apk add --no-cache git nodejs npm
 
 ADD release/linux/arm64/drone-npm /bin/
 ENTRYPOINT [ "/bin/drone-npm" ]

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -26,6 +26,7 @@ type (
 		Username              string
 		Password              string
 		Token                 string
+		SkipWhoami            bool
 		Email                 string
 		Registry              string
 		Folder                string
@@ -219,7 +220,9 @@ func (p *Plugin) authenticate() error {
 	}
 
 	// Write whoami command to verify credentials
-	cmds = append(cmds, whoamiCommand())
+	if !p.settings.SkipWhoami {
+		cmds = append(cmds, whoamiCommand())
+	}
 
 	// Run commands
 	err := runCommands(cmds, p.settings.Folder)


### PR DESCRIPTION
Some private npm registries (like [GitLab](https://gitlab.com/gitlab-org/gitlab/-/issues/277387)) have not implemented the `whoami` endpoint, so we can't use this plugin with them.
This PR adds an option to allow skip the `whoami` command.