### PR TITLE
Remove standard http ports from registry URL when writing authToken

### DIFF
--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -297,6 +298,10 @@ func npmrcContentsUsernamePassword(config Settings) string {
 func npmrcContentsToken(config Settings) string {
 	registry, _ := url.Parse(config.Registry)
 	registry.Scheme = "" // Reset the scheme to empty. This makes it so we will get a protocol relative URL.
+	host, port, _ := net.SplitHostPort(registry.Host)
+	if port == "80" || port == "443" {
+		registry.Host = host // Remove standard ports as they're not supported in authToken since NPM 7.
+	}
 	registryString := registry.String()
 
 	if !strings.HasSuffix(registryString, "/") {


### PR DESCRIPTION
The latest release of this plugin included an update of the NPM client from v6 to v8, which changed the authentication behaviour of the client.

If a private registry URL contains standard http port 80 or 443 when performing an `npm login / adduser` command the port number is removed when writing the authToken to the .npmrc file. If the port remains in the authToken registry URL then the token is ignored when running commands like `npm whoami` or `npm publish` and results in an error asking to run `npm adduser`.  

Because this plugin writes the .npmrc file directly we need to remove the port from the registry URL before writing.

Example:
```
# Configure registry
npm config set registry https://private.registry.com:443
```

Invalid `.npmrc` authToken
```
//private.registry.com:443/:_authToken=$TOKEN
```

Valid `.npmrc` authToken
```
//private.registry.com/:_authToken=$TOKEN
```