### PR TITLE
Updating validation to ignore default ports as well as a flag for skipping the registry validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,38 @@ docker build \
 ```
 
 ## Usage
-
+### Standard Local Usage
 ```console
 docker run --rm \
   -e NPM_USERNAME=drone \
   -e NPM_PASSWORD=password \
   -e NPM_EMAIL=drone@drone.io \
+  -v $(pwd):$(pwd) \
+  -w $(pwd) \
+  plugins/npm
+```
+#### With a specified registry for validation
+This will allow the setting of the defautl publishing registry. This will also raise a validation error if the publish configuration of the npm package is not pointing to the specified registry.
+```console
+docker run --rm \
+  -e NPM_USERNAME=drone \
+  -e NPM_PASSWORD=password \
+  -e NPM_EMAIL=drone@drone.io \
+  -e NPM_REGISTRY="https://fakenpm.reg.org/good/path" \
+  -v $(pwd):$(pwd) \
+  -w $(pwd) \
+  plugins/npm
+```
+
+#### Ignore registry validation
+This will all the setting of a default publishing registry but will skip the verification of it being the same as the one in the npmrc. In this instance no validation error is raised and the registry in the npm rc is used
+```console
+docker run --rm \
+  -e NPM_USERNAME=drone \
+  -e NPM_PASSWORD=password \
+  -e NPM_EMAIL=drone@drone.io \
+  -e NPM_REGISTRY="https://fakenpm.reg.org/good/path" \
+  -e PLUGIN_SKIP_REGISTRY_VALIDATION=true \
   -v $(pwd):$(pwd) \
   -w $(pwd) \
   plugins/npm

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,11 @@ require (
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.8.1 h1:CGuYNZF9IKZY/rfBe3lJpccSoIY1ytfvmgQT90cNOl4=
 github.com/urfave/cli/v2 v2.8.1/go.mod h1:Z41J9TPoffeoqP0Iza0YbAhGvymRdZAd2uPmZ5JxRdY=
@@ -52,4 +54,6 @@ golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/main.go
+++ b/main.go
@@ -132,8 +132,8 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			EnvVars:     []string{"PLUGIN_ACCESS"},
 			Destination: &settings.Access,
 		},
-		&cli.StringFlag{
-			Name:        "skipRegistryUriValidation",
+		&cli.BoolFlag{
+			Name:        "skip-registry-validation",
 			Usage:       "skips validation for uri in package.json and the currently configured registry",
 			EnvVars:     []string{"PLUGIN_SKIP_URI_VALIDATION"},
 			Destination: &settings.SkipRegistryUriValidation,

--- a/main.go
+++ b/main.go
@@ -135,8 +135,8 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 		&cli.BoolFlag{
 			Name:        "skip-registry-validation",
 			Usage:       "skips validation for uri in package.json and the currently configured registry",
-			EnvVars:     []string{"PLUGIN_SKIP_URI_VALIDATION"},
-			Destination: &settings.SkipRegistryUriValidation,
+			EnvVars:     []string{"PLUGIN_SKIP_REGISTRY_VALIDATION"},
+			Destination: &settings.SkipRegistryValidation,
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -132,5 +132,11 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			EnvVars:     []string{"PLUGIN_ACCESS"},
 			Destination: &settings.Access,
 		},
+		&cli.StringFlag{
+			Name:        "skipRegistryUriValidation",
+			Usage:       "skips validation for uri in package.json and the currently configured registry",
+			EnvVars:     []string{"PLUGIN_SKIP_URI_VALIDATION"},
+			Destination: &settings.SkipRegistryUriValidation,
+		},
 	}
 }

--- a/plugin/__test__/package.json
+++ b/plugin/__test__/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "my-awesome-package",
+    "version": "1.0.0",
+    "author": "Your Name <email@example.com> (https://example.com)",
+    "publishConfig": {
+        "registry": "https://fakenpm.reg.org/good/path"
+    }
+}

--- a/plugin/__testwithport__/package.json
+++ b/plugin/__testwithport__/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "my-awesome-package",
+    "version": "1.0.0",
+    "author": "Your Name <email@example.com> (https://example.com)",
+    "publishConfig": {
+        "registry": "https://fakenpm.reg.org:443/good/path"
+    }
+}

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -58,7 +58,11 @@ var defaultPortMap = map[string]string{
 	"https": "443",
 }
 
-func isDefaultOrNilPort(u *url.URL) bool {
+func isNilPortOrStandardSchemePort(u *url.URL) bool {
+	if !strings.HasPrefix(u.Scheme, "http") {
+		//invalid schemes aren't worth checking
+		return false
+	}
 	if u.Port() != "" {
 		if port, ok := defaultPortMap[u.Scheme]; ok {
 			return port == u.Port()
@@ -84,8 +88,8 @@ func (p *Plugin) CheckMatchingUrlWithDefaultPorts() (bool, error) {
 	}
 	compareWithoutDefaultPorts := strings.Compare(parsedConifgReg.Hostname(), parsedSettingsReg.Hostname()) == 0 &&
 		strings.Compare(parsedConifgReg.Scheme, parsedSettingsReg.Scheme) == 0 &&
-		isDefaultOrNilPort(parsedConifgReg) &&
-		isDefaultOrNilPort(parsedSettingsReg)
+		isNilPortOrStandardSchemePort(parsedConifgReg) &&
+		isNilPortOrStandardSchemePort(parsedSettingsReg)
 	return compareWithoutDefaultPorts, nil
 }
 
@@ -129,7 +133,7 @@ func (p *Plugin) Validate() error {
 	if p.settings.SkipRegistryUriValidation {
 		p.settings.npm = npm
 		return nil
-	} else if strings.Compare(p.settings.Registry, npm.Config.Registry) != 0 || registriesMatchWithDefaultPorts {
+	} else if strings.Compare(p.settings.Registry, npm.Config.Registry) != 0 && !registriesMatchWithDefaultPorts {
 		return fmt.Errorf("registry values do not match .drone.yml: %s package.json: %s", p.settings.Registry, npm.Config.Registry)
 	}
 

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -77,10 +77,10 @@ func isNilPortOrStandardSchemePort(u *url.URL) bool {
 	return true
 }
 
-func (p *Plugin) CheckMatchingUrlWithDefaultPorts() (bool, error) {
-	parsedConifgReg, err := url.Parse(p.settings.npm.Config.Registry)
+func (p *Plugin) CheckMatchingUrlWithDefaultPorts(nc npmConfig) (bool, error) {
+	parsedConifgReg, err := url.Parse(nc.Registry)
 	if err != nil {
-		return false, fmt.Errorf("package.json registry: %s failed to parse.", p.settings.npm.Config.Registry)
+		return false, fmt.Errorf("package.json registry: %s failed to parse.", nc.Registry)
 	}
 	parsedSettingsReg, err := url.Parse(p.settings.Registry)
 	if err != nil {
@@ -88,6 +88,7 @@ func (p *Plugin) CheckMatchingUrlWithDefaultPorts() (bool, error) {
 	}
 	compareWithoutDefaultPorts := strings.Compare(parsedConifgReg.Hostname(), parsedSettingsReg.Hostname()) == 0 &&
 		strings.Compare(parsedConifgReg.Scheme, parsedSettingsReg.Scheme) == 0 &&
+		strings.Compare(parsedConifgReg.Path, parsedSettingsReg.Path) == 0 &&
 		isNilPortOrStandardSchemePort(parsedConifgReg) &&
 		isNilPortOrStandardSchemePort(parsedSettingsReg)
 	return compareWithoutDefaultPorts, nil
@@ -126,7 +127,7 @@ func (p *Plugin) Validate() error {
 		p.settings.Registry = globalRegistry
 	}
 
-	registriesMatchWithDefaultPorts, err := p.CheckMatchingUrlWithDefaultPorts()
+	registriesMatchWithDefaultPorts, err := p.CheckMatchingUrlWithDefaultPorts(npm.Config)
 	if err != nil {
 		registriesMatchWithDefaultPorts = false // if there's an error using this default to standard validation by string compare
 	}

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -23,17 +23,17 @@ import (
 type (
 	// Settings for the Plugin.
 	Settings struct {
-		Username                  string
-		Password                  string
-		Token                     string
-		SkipWhoami                bool
-		Email                     string
-		Registry                  string
-		Folder                    string
-		FailOnVersionConflict     bool
-		Tag                       string
-		Access                    string
-		SkipRegistryUriValidation bool
+		Username               string
+		Password               string
+		Token                  string
+		SkipWhoami             bool
+		Email                  string
+		Registry               string
+		Folder                 string
+		FailOnVersionConflict  bool
+		Tag                    string
+		Access                 string
+		SkipRegistryValidation bool
 
 		npm *npmPackage
 	}
@@ -125,7 +125,7 @@ func (p *Plugin) Validate() error {
 	if err != nil {
 		return fmt.Errorf("issue comparing the registries specified in drone yaml (%s) and package.json: (%s)", p.settings.Registry, npm.Config.Registry) // if there's an error using this default to standard validation by string compare
 	}
-	if !registriesMatch && !p.settings.SkipRegistryUriValidation {
+	if !registriesMatch && !p.settings.SkipRegistryValidation {
 		return fmt.Errorf("registry values do not match .drone.yml: %s package.json: %s", p.settings.Registry, npm.Config.Registry)
 	}
 

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -9,6 +9,14 @@ import (
 	"testing"
 )
 
+func TestisDefaultOrNilPort(t *testing.T){
+	t.Skip()
+}
+
+func TestCheckMatchingUrlWithDefaultPorts(t *testing.T){
+	t.Skip()
+}
+
 func TestValidate(t *testing.T) {
 	t.Skip()
 }

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -31,13 +31,13 @@ func initFakeSettings() Settings {
 		SkipWhoami: false,
 		Email:      "fake@user.tst",
 		// Note: this registry is the one that would come from drone yaml
-		Registry:                  "https://fakenpm.reg.org/good/path",
-		Folder:                    "__test__",
-		FailOnVersionConflict:     true,
-		Tag:                       "",
-		Access:                    "",
-		SkipRegistryUriValidation: false,
-		npm:                       &np,
+		Registry:               "https://fakenpm.reg.org/good/path",
+		Folder:                 "__test__",
+		FailOnVersionConflict:  true,
+		Tag:                    "",
+		Access:                 "",
+		SkipRegistryValidation: false,
+		npm:                    &np,
 	}
 }
 
@@ -227,12 +227,12 @@ func TestValidateWithRegistryVariations(t *testing.T) {
 	}
 
 	// Validation Tests with SkipRegistryCheck
-	p.settings.SkipRegistryUriValidation = true
+	p.settings.SkipRegistryValidation = true
 	p.settings.Registry = "fakenpm.reg.org/good/path"
 	skipMissingSchemeErr := p.Validate()
 	assert.Nil(t, skipMissingSchemeErr)
 
-	p.settings.SkipRegistryUriValidation = true
+	p.settings.SkipRegistryValidation = true
 	p.settings.Registry = "https://fakenpm.reg.org:7894/good/path"
 	skipWeirdPortErr := p.Validate()
 	assert.Nil(t, skipWeirdPortErr)

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -6,17 +6,133 @@
 package plugin
 
 import (
+	"context"
+	"net/url"
 	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/drone-plugins/drone-plugin-lib/drone"
 )
 
-func TestisDefaultOrNilPort(t *testing.T){
+func initFakeSettings() Settings {
+	nc := npmConfig{
+		// Note: this registry is the one that would come from publishConfig in package.json
+		Registry: "https://fakenpm.reg.org",
+	}
+	np := npmPackage{
+		Name:    "Test Package",
+		Version: "1.33.7",
+		Config: nc,
+	}
+	return Settings{
+		Username:   "fakeUser",
+		Password:   "fakePass",
+		Token:      "",
+		SkipWhoami: false,
+		Email:      "fake@user.tst",
+		// Note: this registry is the one that would come from drone yaml
+		Registry:                  "https://fakenpm.reg.org",
+		Folder:                    "folderpath",
+		FailOnVersionConflict:     true,
+		Tag:                       "",
+		Access:                    "",
+		SkipRegistryUriValidation: false,
+		npm: &np,
+	}
+}
+
+func initFakeNetwork() drone.Network {
+	return drone.Network{
+		SkipVerify: true,
+		Client:     nil,
+		Context:    context.TODO(),
+	}
+}
+
+func initFakePipeline() drone.Pipeline {
+	return drone.Pipeline{
+		Build:  drone.Build{},
+		Repo:   drone.Repo{},
+		Commit: drone.Commit{},
+		Stage:  drone.Stage{},
+		Step:   drone.Step{},
+		SemVer: drone.SemVer{},
+		CalVer: drone.CalVer{},
+		System: drone.System{},
+	}
+}
+
+func initPlugin() *Plugin {
+	return &Plugin{
+		settings: initFakeSettings(),
+		pipeline: initFakePipeline(),
+		network:  initFakeNetwork(),
+	}
+}
+
+func getParsedUri(s string) *url.URL{
+	rslt, _ := url.Parse(s)
+	return rslt
+}
+
+func TestisDefaultOrNilPort(t *testing.T) {
+	p := initPlugin()
+
+	resultWithoutPort := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, true, resultWithoutPort)
+
+	p.settings.Registry = "https://fakenpm.reg.org:443"
+	resultWithPort := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, true, resultWithPort)
+
+	p.settings.Registry = "http://fakenpm.reg.org:80"
+	resultWithPortHTTP := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, true, resultWithPortHTTP)
+
+	p.settings.Registry = "fakenpm.reg.org"
+	resultWithoutSchemeOrPort := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, true, resultWithoutSchemeOrPort)
+
+	p.settings.Registry = "fakenpm.reg.org:80"
+	resultWithoutScheme := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, false, resultWithoutScheme)
+
+	p.settings.Registry = "https://fakenpm.reg.org:8443"
+	resultWithNonStandardPort := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, false, resultWithNonStandardPort)
+
+	p.settings.Registry = "https://fakenpm.reg.org:8080"
+	resultWithNonStandardPortHTTP := isDefaultOrNilPort(getParsedUri(p.settings.Registry))
+	assert.Equal(t, false, resultWithNonStandardPortHTTP)
+}
+
+func TestCheckMatchingUrlWithDefaultPorts(t *testing.T) {
 	t.Skip()
 }
 
-func TestCheckMatchingUrlWithDefaultPorts(t *testing.T){
+func TestValidateMissingUsername(t *testing.T) {
 	t.Skip()
 }
-
+func TestValidateMissingPassword(t *testing.T) {
+	t.Skip()
+}
+func TestValidateMissingEmail(t *testing.T) {
+	t.Skip()
+}
+func TestValidateUsingTokenWithMissingFields(t *testing.T) {
+	t.Skip()
+}
+func TestValidateMissingRegistry(t *testing.T) {
+	t.Skip()
+}
+func TestValidateInvalidReg(t *testing.T) {
+	t.Skip()
+}
+func TestValidateRegDefaultPorts(t *testing.T) {
+	t.Skip()
+}
+func TestValidateInvalidRegWithSkipReg(t *testing.T) {
+	t.Skip()
+}
 func TestValidate(t *testing.T) {
 	t.Skip()
 }

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -107,7 +107,7 @@ func TestIsDefaultOrNilPort(t *testing.T) {
 	assert.Equal(t, false, resultWithNonStandardPortHTTP)
 }
 
-func TestCheckMatchingUrlWithDefaultPorts(t *testing.T) {
+func TestCompareRegistries(t *testing.T) {
 	p := initPlugin()
 	goodReg := "https://fakenpm.reg.org/good/path"
 	goodRegWithPort := "https://fakenpm.reg.org:443/good/path"
@@ -115,24 +115,24 @@ func TestCheckMatchingUrlWithDefaultPorts(t *testing.T) {
 
 	p.settings.Registry = goodReg
 	p.settings.npm.Config.Registry = goodReg
-	ValidNoPorts, _ := p.CheckMatchingUrlWithDefaultPorts(p.settings.npm.Config)
+	ValidNoPorts, _ := p.CompareRegistries(p.settings.npm.Config)
 	assert.Equal(t, true, ValidNoPorts)
 
 	p.settings.Registry = goodRegWithPort
-	SameUrlOneWithPort, _ := p.CheckMatchingUrlWithDefaultPorts(p.settings.npm.Config)
+	SameUrlOneWithPort, _ := p.CompareRegistries(p.settings.npm.Config)
 	assert.Equal(t, true, SameUrlOneWithPort)
 
 	p.settings.Registry = goodRegWithPort
 	p.settings.npm.Config.Registry = goodRegWithPort
-	SameUrlBothWithPort, _ := p.CheckMatchingUrlWithDefaultPorts(p.settings.npm.Config)
+	SameUrlBothWithPort, _ := p.CompareRegistries(p.settings.npm.Config)
 	assert.Equal(t, true, SameUrlBothWithPort)
 
 	p.settings.Registry = "invalidUri"
-	invalidUriTest, _ := p.CheckMatchingUrlWithDefaultPorts(p.settings.npm.Config)
+	invalidUriTest, _ := p.CompareRegistries(p.settings.npm.Config)
 	assert.Equal(t, false, invalidUriTest)
 
 	p.settings.Registry = goodRegWithNonStandardPort
-	nonStandardPortTest, _ := p.CheckMatchingUrlWithDefaultPorts(p.settings.npm.Config)
+	nonStandardPortTest, _ := p.CompareRegistries(p.settings.npm.Config)
 	assert.Equal(t, false, nonStandardPortTest)
 }
 


### PR DESCRIPTION
Hello 
Before npm 7 custom npm registries required ports to be in the URI while newer versions do not but they also do not break if the port is included.

Due to some old configs out and about it would be helpful for default ports in URIs to be ignored when validating that the drone yaml provided registry uri against the package.json uri would ignore default ports in comparisons. In order to make the validations and conditions clear I also added in a full test suite for this functionality.

While working on this I also added an an additional flag for skipping validation entirely.

Let me know if either or both of these features are acceptable and merge when able if they are

Thank you
